### PR TITLE
[#72912212] Progressively retry smaller sizes on OutOfMemoryError during rotate

### DIFF
--- a/simple-crop-image-lib/src/eu/janmuller/android/simplecropimage/CropImage.java
+++ b/simple-crop-image-lib/src/eu/janmuller/android/simplecropimage/CropImage.java
@@ -241,6 +241,7 @@ public class CropImage extends MonitoredActivity {
                     return BitmapFactory.decodeStream(in, null, o2);
                 } catch (OutOfMemoryError e) {
                     // Don't return-- keep looping until our inSampleSize doesn't throw OOME
+                    Log.e(TAG, "Decoding bitmap with inSampleSize=" + o2.inSampleSize + " failed. Retrying with inSampleSize= " + (o2.inSampleSize * 2), e);
                 } finally {
                     if (in != null) {
                         in.close();


### PR DESCRIPTION
For some devices that are throwing OutOfMemoryError, retry at a smaller image size (a larger inSampleSize).  

Now that we handle it well, also bump IMAGE_MAX_SIZE so when you take a small area crop there's still decent resolution in the cropped image.
