### PR TITLE
Fix pom dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ target/
 *.iml
 .DS_Store
 build/
+.idea
+local.properties

--- a/simple-crop-image-lib/build.gradle
+++ b/simple-crop-image-lib/build.gradle
@@ -26,10 +26,7 @@ android {
 
     defaultConfig {
         minSdkVersion 4
-        versionName "1.0.0"
-
-        // enforce that maven gets updated. TODO: figure out how to grab versionName from other gradle scripts
-        assert versionName == VERSION_NAME
+        versionName VERSION_NAME
     }
 
     sourceSets {

--- a/simple-crop-image-lib/gradle.properties
+++ b/simple-crop-image-lib/gradle.properties
@@ -2,7 +2,7 @@ POM_NAME=simple-crop-image-lib
 POM_ARTIFACT_ID=simple-crop-image-lib
 POM_PACKAGING=aar
 
-VERSION_NAME=1.0.0
+VERSION_NAME=1.0.1
 GROUP=com.whistle.custom
 
 RELEASE_REPOSITORY_URL=https://whistlerepo1.jfrog.io/whistlerepo1/libs-release-local

--- a/simple-crop-image-lib/gradle/gradle-bintray-push.gradle
+++ b/simple-crop-image-lib/gradle/gradle-bintray-push.gradle
@@ -68,12 +68,26 @@ publishing {
             artifact file("build/outputs/aar/${POM_NAME}-release.aar")
             artifact androidJavadocsJar
             artifact androidSourcesJar
+
+            // AAR publications don't automatically know about our dependencies, so add them to pom manually
+            pom.withXml {
+                def dependenciesNode = asNode().appendNode('dependencies')
+                configurations.compile.allDependencies.each { // only add 'compile' dependencies
+                    if (it.group && it.name && it.version) {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
+                }
+            }
         }
     }
 }
 
 task androidJavadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
     options.addStringOption("tag", 'inspiredby::"Inspired by:"')
 }
 
@@ -85,6 +99,12 @@ task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
 task androidSourcesJar(type: Jar) {
     classifier = 'sources'
     from android.sourceSets.main.java.sourceFiles
+}
+
+afterEvaluate {
+    androidJavadocs.classpath += files(android.libraryVariants.collect { variant ->
+        variant.javaCompile.classpath.files
+    })
 }
 
 def getMavenUsername() {


### PR DESCRIPTION
Add transitive dependencies into pom. Also, put compile dependencies on javadoc classpath

Bolt: `./gradlew -q app:dependencies`

Before:
```
+--- com.whistle.custom:simple-crop-image-lib:1.0.1
```

After:
```
+--- com.whistle.custom:simple-crop-image-lib:1.0.1
|    \--- com.android.support:support-v4:24.0.0 (*)
```
